### PR TITLE
feat(added PER, DTH and PID): added segments to PR855 4010

### DIFF
--- a/lib/stupidedi/transaction_sets/004010/standards/PR855.rb
+++ b/lib/stupidedi/transaction_sets/004010/standards/PR855.rb
@@ -12,6 +12,8 @@ module Stupidedi
           d::TableDef.header("1 - Header",
             s:: ST.use( 10, r::Mandatory, d::RepeatCount.bounded(1)),
             s::BAK.use( 20, r::Mandatory, d::RepeatCount.bounded(1)),
+            s::PER.use( 30, r::Optional, d::RepeatCount.bounded(1)),
+            s::DTM.use( 40, r::Optional, d::RepeatCount.bounded(1)),
 
             d::LoopDef.build("N1", d::RepeatCount.bounded(200),
               s:: N1.use( 310, r::Optional,  d::RepeatCount.bounded(1)),
@@ -22,6 +24,7 @@ module Stupidedi
           d::TableDef.detail("2 - Detail",
             d::LoopDef.build("PO1", d::RepeatCount.bounded(10000),
               s::PO1.use( 10, r::Mandatory, d::RepeatCount.bounded(1)),
+              s::PID.use( 10, r::Optional, d::RepeatCount.bounded(1)),
               s::ACK.use( 10, r::Optional, d::RepeatCount.bounded(1)))),
 
           d::TableDef.summary("3 - Summary",


### PR DESCRIPTION
this commit adds as OPTIONAL three segments, two of them (PER and DTM) were added into the header while PID was added to details, with these changes we are now able to read over the PR855 files that contains it, also, they were added as optionals so it doesn't break in the future if our fork ends up being eligible for a PR

solves invalid segments